### PR TITLE
fix curriculum: Fix typo error in Step 11 of workshop-music-instrument-filter

### DIFF
--- a/curriculum/challenges/english/25-front-end-development/workshop-music-instrument-filter/67213641373a23696b74424b.md
+++ b/curriculum/challenges/english/25-front-end-development/workshop-music-instrument-filter/67213641373a23696b74424b.md
@@ -9,7 +9,7 @@ dashedName: step-11
 
 Within your new function, you need to filter the instruments depending on the selected category.
 
-Filter out items from `instrumentsArr` and make your function return an array containing the instrument objects with the the same category of `instrumentCategory`. If `instrumentCategory` is equal to `all`, return the whole `instrumentsArr` array.
+Filter out items from `instrumentsArr` and make your function return an array containing the instrument objects with the same category of `instrumentCategory`. If `instrumentCategory` is equal to `all`, return the whole `instrumentsArr` array.
 
 Then, remove the `console.log` from the callback of your event listener and log the result of calling `instrumentCards` with the selected option from the dropdown menu as argument so you can test your function selecting different category options.
 


### PR DESCRIPTION
Removes the repeated article 'the' in the description text in Step 11 of workshop-music-instrument-filter

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [ ] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [ ] My pull request targets the `main` branch of freeCodeCamp.
- [ ] I have tested these changes either locally on my machine, or GitPod.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
